### PR TITLE
Corrige erro de cor e brilho da matriz de LEDs RGB aplicando a reversão de byte

### DIFF
--- a/neopixel_pio/neopixel_pio.c
+++ b/neopixel_pio/neopixel_pio.c
@@ -25,6 +25,25 @@ PIO np_pio;
 uint sm;
 
 /**
+ * Reverte a ordem de um byte LSB -> MSB e sucessivamente.
+ * @param b o byte a ser revertido
+ */
+uint8_t reverse_byte(uint8_t b) {
+  uint8_t reversed = 0; // Inicializa o byte a ser revertido
+
+  // Faz a reversão bit a bit seguindo a lógica: 
+  // 1. Captura o i-ésimo bit do byte original ((b >> i) & 0x1)
+  // 2. Envia-o para a variável reversed com o operador |
+  // 3. Arrasta o bit transferido para a esquerda (reversed << 1)
+  for (uint8_t i = 0; i < 8; i++) {
+    reversed = reversed << 1; // 
+    reversed = (reversed | ((b >> i) & 0x1)); 
+  }
+
+  return reversed;
+}
+
+/**
  * Inicializa a máquina PIO para controle da matriz de LEDs.
  */
 void npInit(uint pin) {
@@ -55,9 +74,13 @@ void npInit(uint pin) {
  * Atribui uma cor RGB a um LED.
  */
 void npSetLED(const uint index, const uint8_t r, const uint8_t g, const uint8_t b) {
-  leds[index].R = r;
-  leds[index].G = g;
-  leds[index].B = b;
+  uint8_t reversed_r = reverse_byte(r);
+  uint8_t reversed_g = reverse_byte(g);
+  uint8_t reversed_b = reverse_byte(b);
+
+  leds[index].R = reversed_r;
+  leds[index].G = reversed_g;
+  leds[index].B = reversed_b;
 }
 
 /**


### PR DESCRIPTION
Conforme levantado nas discussões no Discord, o LED RGB WS2818 recebe os bytes RGB do MSB -> LSB. 
Do jeito que a biblioteca está escrita, o envio é feito do LSB -> MSB. Por consequência, os comandos para mudança de cor e/ou diminuição de brilho ficam não intuitivos (O brilho aumenta conforme o número diminui, as cores ficam esmaecidas, etc.).

É possível solucionar o problema aplicando uma lógica de reversão de byte antes de enviá-lo para o WS2818. Assim, o usuário envia os valores RGB de forma intuitiva e, internamente, a biblioteca aplica a reversão e envia o valor tratado à matriz de LEDs. 

Esse PR implementa uma função para a reversão de bytes `uint8_t reverse_byte(uint8_t b)` bem como integra-o no código já existente, na função `void npSetLED(const uint index, const uint8_t r, const uint8_t g, const uint8_t b)`.

Essas modificações tornam o controle de brilho mais intuitivo, onde 0 e 255 significam mínimo e máximo brilho, respectivamente. 